### PR TITLE
Fix copy-paste typo

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -115,7 +115,7 @@ instance.register(bootstrap, {
 instance.listen(3000);
 ```
 
-*handlers/first.controller.ts*:
+*controllers/first.controller.ts*:
 ```typescript
 import { Controller, GET } from 'fastify-decorators';
 


### PR DESCRIPTION
'handlers/first.controller.ts' should be 'controllers/first.controller.ts', because in controllersDirectory prop we declare controllers directory as controllers source