### PR TITLE
feat: adds helper type for using configureControllerTest with singelton controllers

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -75,11 +75,11 @@ _Example_:
 
 ```ts
 import { FastifyInstance } from 'fastify';
-import { configureControllerTest } from 'fastify-decorators/testing';
+import { configureControllerTest, FastifyInstanceWithController } from 'fastify-decorators/testing';
 import { AuthController } from '../src/auth.controller';
 
 describe('Controller: AuthController', () => {
-  let instance: FastifyInstance;
+  let instance: FastifyInstanceWithController<AuthController>;
 
   beforeEach(async () => {
     instance = await configureControllerTest({

--- a/lib/testing/configure-controller-test.ts
+++ b/lib/testing/configure-controller-test.ts
@@ -28,9 +28,11 @@ export interface ControllerTestConfig<C = any> {
   mocks?: ServiceMock[];
 }
 
+export type FastifyInstanceWithController<C> = FastifyInstance & Pick<ControllerTestConfig<C>, 'controller'>;
+
 export async function configureControllerTest<C>(
   config: ControllerTestConfig<Constructor<C>>,
-): Promise<FastifyInstance & { controller: C }> {
+): Promise<FastifyInstanceWithController<C>> {
   const instance = fastify();
   const injectablesWithMocks = MocksManager.create(injectables, config.mocks);
   if (!injectablesWithMocks.has(FastifyInstanceToken)) {

--- a/lib/testing/index.ts
+++ b/lib/testing/index.ts
@@ -7,5 +7,9 @@
  */
 
 export type { ServiceMock } from './service-mock';
-export { ControllerTestConfig, configureControllerTest } from './configure-controller-test';
+export {
+  ControllerTestConfig,
+  FastifyInstanceWithController,
+  configureControllerTest,
+} from './configure-controller-test';
 export { ServiceTestConfig, configureServiceTest } from './configure-service-test';


### PR DESCRIPTION
**Problem description:**

Suppose you use `beforeEach` to bootstrap controller for each test case:
```ts
let instance: FastifyInstance;
beforeEach(async () => {
  instance = await configureControllerTest({
    controller: AuthController,
  });
});

afterEach(() => jest.restoreAllMocks());

it(`should extend SomeSuperClass`, () => {
  expect(instance.controller instanceof SomeSuperClass).toBe(true);
});
```

TypeScript will complain:
```
Property 'controller' does not exist on type 'FastifyInstance<Server, IncomingMessage, ServerResponse, FastifyLoggerInstance>'.ts(2339
```

You could instead do
```ts
let instance: FastifyInstanceWithController<AuthController>;

// ...

// this would pass type checks
it(`should extend SomeSuperClass`, () => {
  expect(instance.controller instanceof SomeSuperClass).toBe(true);
});
```

For other uses cases, where controller is bootstrapped as, say `const`, type is inferred correctly, and this type is not necessary.